### PR TITLE
Fix interpolation being FPS-dependent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+### Fixed
 
-- Fixed interpolation being FPS-dependent
+- Interpolation is no longer FPS-dependent. It now matches the previous behavior at 60 Hz regardless of the rendered framerate.
 
 ## [1.1.1] - 2023-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Fixed interpolation being FPS-dependent
+
 ## [1.1.1] - 2023-03-20
 
 ### Changed

--- a/addons/interpolated_camera_3d/interpolated_camera_3d.gd
+++ b/addons/interpolated_camera_3d/interpolated_camera_3d.gd
@@ -31,9 +31,8 @@ func _process(delta: float) -> void:
 	if not target is Node3D:
 		return
 
-	# TODO: Fix delta calculation so it behaves correctly if the speed is set to 1.0.
-	var translate_factor := translate_speed * delta * 10
-	var rotate_factor := rotate_speed * delta * 10
+	var translate_factor := 1 - pow(1 - translate_speed, delta * 3.45233)
+	var rotate_factor := 1 - pow(1 - rotate_speed, delta * 3.45233)
 	var target_xform := target.get_global_transform()
 	# Interpolate the origin and basis separately so we can have different translation and rotation
 	# interpolation speeds.
@@ -50,8 +49,8 @@ func _process(delta: float) -> void:
 		# and disabled on the Camera3D.
 		if camera.projection == projection:
 			# Interpolate the near and far clip plane distances.
-			var near_far_factor := near_far_speed * delta * 10
-			var fov_factor := fov_speed * delta * 10
+			var near_far_factor := 1 - pow(1 - near_far_speed, delta * 3.45233)
+			var fov_factor := 1 - pow(1 - fov_speed, delta * 3.45233)
 			var new_near := lerp(near, camera.near, near_far_factor) as float
 			var new_far := lerp(far, camera.far, near_far_factor) as float
 


### PR DESCRIPTION
The interpolation was producing different behaviors at different FPS values.

At 10 FPS the distance the camera moved was very short and at 300 FPS it was much larger relative to the target which was moving at the same global speed in both cases (27 m/s).

3.45233 was chosen to mimick the previous behavior running at 60 FPS.

With this change the TODO comment and issue #1 seems to be resolved as well.